### PR TITLE
feat: configuration par type de vol (remb. km, points, coût, défraiement, visibilité)

### DIFF
--- a/Http/Web/Controller/StatisticalGraphController.php
+++ b/Http/Web/Controller/StatisticalGraphController.php
@@ -135,8 +135,7 @@ final class StatisticalGraphController extends WebController
         $legend = [];
         $graphByTypeAndYear->type = [];
         foreach (fetchBbcFlightTypes() as $flightType) {
-
-            if (!in_array($flightType->numero, [1, 2, 3,4, 6])) {
+            if (!$flightType->isVisibleGraphique()) {
                 continue;
             }
 

--- a/admin/vol.php
+++ b/admin/vol.php
@@ -30,10 +30,14 @@ if($action === ACTION_SAVE){
         $res = $flightType->fetch($flightTypeId);
         if($res > 0 ){
             $flightType->fkService = $serviceId;
+            $flightType->remboursement_km = price2num(GETPOST('remboursement_km_'.$flightTypeId));
+            $flightType->points_pilote    = (int) GETPOST('points_pilote_'.$flightTypeId, 'int');
+            $flightType->cout_pilote      = price2num(GETPOST('cout_pilote_'.$flightTypeId));
+            $flightType->defraiement      = price2num(GETPOST('defraiement_'.$flightTypeId));
+            $flightType->visible_graphique = GETPOST('visible_graphique_'.$flightTypeId) ? 1 : 0;
+            $flightType->visible_tableau   = GETPOST('visible_tableau_'.$flightTypeId) ? 1 : 0;
             $flightType->update($user);
         }
-
-        dolibarr_set_const($db, 'BBC_POINTS_BONUS_'.$flightTypeId, GETPOST('points_bonus_'.$flightTypeId), 'chaine', 0, 'Points pour le vol T'.$flightTypeId, $conf->entity);
     }
 
     dolibarr_set_const($db, 'BBC_FLIGHT_TYPE_CUSTOMER', GETPOST('customer_product'), 'chaine', 0, '', $conf->entity);
@@ -65,39 +69,64 @@ print load_fiche_titre($langs->trans("FLightLogSetup"), $linkback, 'title_setup'
         <input type="hidden" name="action" value="<?= ACTION_SAVE ?>"/>
         <input type="hidden" name="token" value="<?php echo newToken(); ?>"/>
 
-        <!-- Service mapping -->
+        <!-- Configuration par type de vol -->
+        <h3><?= $langs->trans("Configuration par type de vol") ?></h3>
         <table class="noborder" width="100%">
             <tr class="liste_titre">
-                <th><?= $langs->trans("Types de vol.") ?></th>
+                <th><?= $langs->trans("Type de vol") ?></th>
                 <th><?= $langs->trans("Service / produit") ?></th>
+                <th><?= $langs->trans("Remb. km (€/km)") ?></th>
+                <th><?= $langs->trans("Points pilote") ?></th>
+                <th><?= $langs->trans("Coût pilote (€)") ?></th>
+                <th><?= $langs->trans("Défraiement (€)") ?></th>
+                <th><?= $langs->trans("Visible graphique") ?></th>
+                <th><?= $langs->trans("Visible tableau") ?></th>
             </tr>
 
             <?php foreach ($flightType->lines as $flightTypeLine): ?>
-                <!-- <?= $flightTypeLine->nom; ?>-->
                 <tr class="<?= $flightTypeLine->id % 2 == 0 ? "pair" : "impair" ?>">
                     <td>(T<?= $flightTypeLine->numero ?>) - <?= $flightTypeLine->nom ?></td>
                     <td>
                         <?php $form->select_produits($flightTypeLine->fkService, 'idprod['.$flightTypeLine->id.']', $filtertype, $conf->product->limit_size, $buyer->price_level, 1, 2, '', 1, array(),$buyer->id); ?>
                     </td>
+                    <td>
+                        <input type="number" step="0.001" name="remboursement_km_<?= $flightTypeLine->id ?>"
+                               value="<?= $flightTypeLine->remboursement_km ?>" style="width:80px"/>
+                    </td>
+                    <td>
+                        <input type="number" step="1" name="points_pilote_<?= $flightTypeLine->id ?>"
+                               value="<?= $flightTypeLine->points_pilote ?>" style="width:70px"/>
+                    </td>
+                    <td>
+                        <input type="number" step="0.01" name="cout_pilote_<?= $flightTypeLine->id ?>"
+                               value="<?= $flightTypeLine->cout_pilote ?>" style="width:80px"/>
+                    </td>
+                    <td>
+                        <input type="number" step="0.01" name="defraiement_<?= $flightTypeLine->id ?>"
+                               value="<?= $flightTypeLine->defraiement ?>" style="width:80px"/>
+                    </td>
+                    <td style="text-align:center">
+                        <input type="checkbox" name="visible_graphique_<?= $flightTypeLine->id ?>"
+                               value="1" <?= $flightTypeLine->visible_graphique ? 'checked' : '' ?>/>
+                    </td>
+                    <td style="text-align:center">
+                        <input type="checkbox" name="visible_tableau_<?= $flightTypeLine->id ?>"
+                               value="1" <?= $flightTypeLine->visible_tableau ? 'checked' : '' ?>/>
+                    </td>
                 </tr>
             <?php endforeach; ?>
 
-
             <tr class="impair">
-                <td>
-                    Vol client
-                </td>
-                <td>
+                <td>Vol client</td>
+                <td colspan="7">
                     <?php $form->select_produits($conf->global->BBC_FLIGHT_TYPE_CUSTOMER, 'customer_product',
                         $filtertype, $conf->product->limit_size, $buyer->price_level, 1, 2, '', 1, array(),$buyer->id); ?>
                 </td>
             </tr>
 
             <tr class="pair">
-                <td>
-                    Client par défaut
-                </td>
-                <td>
+                <td>Client par défaut</td>
+                <td colspan="7">
                     <?php echo $form->select_thirdparty_list($conf->global->BBC_FLIGHT_DEFAULT_CUSTOMER, 'defaultCustomer'); ?>
                 </td>
             </tr>
@@ -105,51 +134,32 @@ print load_fiche_titre($langs->trans("FLightLogSetup"), $linkback, 'title_setup'
         </table>
 
 
+        <h3><?= $langs->trans("Points rôles spéciaux") ?></h3>
         <table class="noborder mt-2" width="100%">
             <tr class="liste_titre">
                 <th><?= $langs->trans("Champ") ?></th>
                 <th><?= $langs->trans("Valeur") ?></th>
             </tr>
 
-            <tr class="impar">
-                <td>
-                    <?php echo $langs->trans('Points par type de vols')?>
-                </td>
-
-                <td>
-                <?php foreach ($flightType->lines as $flightTypeLine): ?>
-                    <label for="points_bonus_<?php echo $flightTypeLine->numero; ?>">
-                        (T<?php echo $flightTypeLine->numero ?>) - <?php echo $flightTypeLine->nom ?>
-                    </label>
-                    <?php $prop = 'BBC_POINTS_BONUS_'.$flightTypeLine->numero; ?>
-                    <input type="number" id="points_bonus_<?php echo $flightTypeLine->numero; ?>" name="points_bonus_<?php echo $flightTypeLine->numero; ?>" value="<?php echo $conf->global->$prop?>" />
-                    <br/>
-                <?php endforeach; ?>
-                </td>
-            </tr>
-
             <tr class="pair">
+                <td><?php echo $langs->trans('Points organisateur')?></td>
                 <td>
-                    <?php echo $langs->trans('Points organisateur')?>
-                </td>
-
-                <td>
-                    <input type="number" id="points_bonus_organisator" name="points_bonus_organisator" value="<?php echo $conf->global->BBC_POINTS_BONUS_ORGANISATOR?>" />
+                    <input type="number" id="points_bonus_organisator" name="points_bonus_organisator"
+                           value="<?php echo $conf->global->BBC_POINTS_BONUS_ORGANISATOR?>" />
                 </td>
             </tr>
 
             <tr class="impar">
+                <td><?php echo $langs->trans('Points instructeur')?></td>
                 <td>
-                    <?php echo $langs->trans('Points instructeur')?>
-                </td>
-
-                <td>
-                    <input type="number" id="points_bonus_instructor" name="points_bonus_instructor" value="<?php echo $conf->global->BBC_POINTS_BONUS_INSTRUCTOR?>" />
+                    <input type="number" id="points_bonus_instructor" name="points_bonus_instructor"
+                           value="<?php echo $conf->global->BBC_POINTS_BONUS_INSTRUCTOR?>" />
                 </td>
             </tr>
         </table>
 
 
+        <h3><?= $langs->trans("Paramètres de facturation") ?></h3>
         <table class="noborder mt-2" width="100%">
             <tr class="liste_titre">
                 <th><?= $langs->trans("Champ") ?></th>
@@ -157,27 +167,21 @@ print load_fiche_titre($langs->trans("FLightLogSetup"), $linkback, 'title_setup'
             </tr>
 
             <tr class="pair">
-                <td>
-                    <?php echo $langs->trans('Compte en banque par défaut') ?>
-                </td>
+                <td><?php echo $langs->trans('Compte en banque par défaut') ?></td>
                 <td>
                     <?php $form->select_comptes($conf->global->BBC_DEFAULT_BANK_ACCOUNT, 'default_bank_account', 0, '', 1); ?>
                 </td>
             </tr>
 
             <tr class="impair">
-                <td>
-                    <?php echo $langs->trans('Condition de vente par défaut') ?>
-                </td>
+                <td><?php echo $langs->trans('Condition de vente par défaut') ?></td>
                 <td>
                     <?php $form->select_conditions_paiements($conf->global->BBC_DEFAULT_PAYMENT_TERM_ID, 'bill_condition'); ?>
                 </td>
             </tr>
 
             <tr class="pair">
-                <td>
-                    <?php echo $langs->trans('Type de payement par défaut') ?>
-                </td>
+                <td><?php echo $langs->trans('Type de payement par défaut') ?></td>
                 <td>
                     <?php $form->select_types_paiements($conf->global->BBC_DEFAULT_PAYMENT_TYPE_ID, 'bill_payment_type'); ?>
                 </td>
@@ -185,6 +189,7 @@ print load_fiche_titre($langs->trans("FLightLogSetup"), $linkback, 'title_setup'
         </table>
 
 
+        <h3><?= $langs->trans("Notifications") ?></h3>
         <table class="noborder mt-2" width="100%">
             <tr class="liste_titre">
                 <th><?= $langs->trans("Champ") ?></th>
@@ -192,9 +197,7 @@ print load_fiche_titre($langs->trans("FLightLogSetup"), $linkback, 'title_setup'
             </tr>
 
             <tr class="impair">
-                <td>
-                    <?php echo $langs->trans('E-mail additionel sur les erreurs') ?>
-                </td>
+                <td><?php echo $langs->trans('E-mail additionel sur les erreurs') ?></td>
                 <td>
                     <textarea rows="4" cols="80" name="damage_emails"><?php echo $conf->global->BBC_DAMAGE_EMAILS; ?></textarea>
                     <br/><span class="text-muted">Separer par des ; </span>

--- a/admin/vol.php
+++ b/admin/vol.php
@@ -1,6 +1,4 @@
 <?php
-//require '../../main.inc.php';
-
 require '../../main.inc.php';
 
 require_once '../../core/lib/admin.lib.php';
@@ -17,29 +15,12 @@ if (!$user->admin) {
     accessforbidden();
 }
 
-$flightType = new Bbctypes($db);
 $action = GETPOST('action', 'alpha', 2);
-$services = GETPOST('idprod', 'array', 2);
 
 /*
  * Actions
  */
-// Save
-if($action === ACTION_SAVE){
-    foreach($services as $flightTypeId => $serviceId){
-        $res = $flightType->fetch($flightTypeId);
-        if($res > 0 ){
-            $flightType->fkService = $serviceId;
-            $flightType->remboursement_km = price2num(GETPOST('remboursement_km_'.$flightTypeId));
-            $flightType->points_pilote    = (int) GETPOST('points_pilote_'.$flightTypeId, 'int');
-            $flightType->cout_pilote      = price2num(GETPOST('cout_pilote_'.$flightTypeId));
-            $flightType->defraiement      = price2num(GETPOST('defraiement_'.$flightTypeId));
-            $flightType->visible_graphique = GETPOST('visible_graphique_'.$flightTypeId) ? 1 : 0;
-            $flightType->visible_tableau   = GETPOST('visible_tableau_'.$flightTypeId) ? 1 : 0;
-            $flightType->update($user);
-        }
-    }
-
+if ($action === ACTION_SAVE) {
     dolibarr_set_const($db, 'BBC_FLIGHT_TYPE_CUSTOMER', GETPOST('customer_product'), 'chaine', 0, '', $conf->entity);
     dolibarr_set_const($db, 'BBC_FLIGHT_DEFAULT_CUSTOMER', GETPOST('defaultCustomer'), 'chaine', 0, '', $conf->entity);
 
@@ -56,7 +37,6 @@ if($action === ACTION_SAVE){
  */
 
 $form = new Form($db);
-$flightType->fetchAll();
 
 llxHeader('', $langs->trans("FLightLogSetup"), $help_url);
 
@@ -69,68 +49,27 @@ print load_fiche_titre($langs->trans("FLightLogSetup"), $linkback, 'title_setup'
         <input type="hidden" name="action" value="<?= ACTION_SAVE ?>"/>
         <input type="hidden" name="token" value="<?php echo newToken(); ?>"/>
 
-        <!-- Configuration par type de vol -->
-        <h3><?= $langs->trans("Configuration par type de vol") ?></h3>
+        <h3><?= $langs->trans("Configuration générale") ?></h3>
         <table class="noborder" width="100%">
             <tr class="liste_titre">
-                <th><?= $langs->trans("Type de vol") ?></th>
-                <th><?= $langs->trans("Service / produit") ?></th>
-                <th><?= $langs->trans("Remb. km (€/km)") ?></th>
-                <th><?= $langs->trans("Points pilote") ?></th>
-                <th><?= $langs->trans("Coût pilote (€)") ?></th>
-                <th><?= $langs->trans("Défraiement (€)") ?></th>
-                <th><?= $langs->trans("Visible graphique") ?></th>
-                <th><?= $langs->trans("Visible tableau") ?></th>
+                <th><?= $langs->trans("Champ") ?></th>
+                <th><?= $langs->trans("Valeur") ?></th>
             </tr>
-
-            <?php foreach ($flightType->lines as $flightTypeLine): ?>
-                <tr class="<?= $flightTypeLine->id % 2 == 0 ? "pair" : "impair" ?>">
-                    <td>(T<?= $flightTypeLine->numero ?>) - <?= $flightTypeLine->nom ?></td>
-                    <td>
-                        <?php $form->select_produits($flightTypeLine->fkService, 'idprod['.$flightTypeLine->id.']', $filtertype, $conf->product->limit_size, $buyer->price_level, 1, 2, '', 1, array(),$buyer->id); ?>
-                    </td>
-                    <td>
-                        <input type="number" step="0.001" name="remboursement_km_<?= $flightTypeLine->id ?>"
-                               value="<?= $flightTypeLine->remboursement_km ?>" style="width:80px"/>
-                    </td>
-                    <td>
-                        <input type="number" step="1" name="points_pilote_<?= $flightTypeLine->id ?>"
-                               value="<?= $flightTypeLine->points_pilote ?>" style="width:70px"/>
-                    </td>
-                    <td>
-                        <input type="number" step="0.01" name="cout_pilote_<?= $flightTypeLine->id ?>"
-                               value="<?= $flightTypeLine->cout_pilote ?>" style="width:80px"/>
-                    </td>
-                    <td>
-                        <input type="number" step="0.01" name="defraiement_<?= $flightTypeLine->id ?>"
-                               value="<?= $flightTypeLine->defraiement ?>" style="width:80px"/>
-                    </td>
-                    <td style="text-align:center">
-                        <input type="checkbox" name="visible_graphique_<?= $flightTypeLine->id ?>"
-                               value="1" <?= $flightTypeLine->visible_graphique ? 'checked' : '' ?>/>
-                    </td>
-                    <td style="text-align:center">
-                        <input type="checkbox" name="visible_tableau_<?= $flightTypeLine->id ?>"
-                               value="1" <?= $flightTypeLine->visible_tableau ? 'checked' : '' ?>/>
-                    </td>
-                </tr>
-            <?php endforeach; ?>
 
             <tr class="impair">
                 <td>Vol client</td>
-                <td colspan="7">
+                <td>
                     <?php $form->select_produits($conf->global->BBC_FLIGHT_TYPE_CUSTOMER, 'customer_product',
-                        $filtertype, $conf->product->limit_size, $buyer->price_level, 1, 2, '', 1, array(),$buyer->id); ?>
+                        $filtertype, $conf->product->limit_size, $buyer->price_level, 1, 2, '', 1, array(), $buyer->id); ?>
                 </td>
             </tr>
 
             <tr class="pair">
                 <td>Client par défaut</td>
-                <td colspan="7">
+                <td>
                     <?php echo $form->select_thirdparty_list($conf->global->BBC_FLIGHT_DEFAULT_CUSTOMER, 'defaultCustomer'); ?>
                 </td>
             </tr>
-
         </table>
 
 
@@ -142,18 +81,18 @@ print load_fiche_titre($langs->trans("FLightLogSetup"), $linkback, 'title_setup'
             </tr>
 
             <tr class="pair">
-                <td><?php echo $langs->trans('Points organisateur')?></td>
+                <td><?php echo $langs->trans('Points organisateur') ?></td>
                 <td>
                     <input type="number" id="points_bonus_organisator" name="points_bonus_organisator"
-                           value="<?php echo $conf->global->BBC_POINTS_BONUS_ORGANISATOR?>" />
+                           value="<?php echo $conf->global->BBC_POINTS_BONUS_ORGANISATOR ?>" />
                 </td>
             </tr>
 
             <tr class="impar">
-                <td><?php echo $langs->trans('Points instructeur')?></td>
+                <td><?php echo $langs->trans('Points instructeur') ?></td>
                 <td>
                     <input type="number" id="points_bonus_instructor" name="points_bonus_instructor"
-                           value="<?php echo $conf->global->BBC_POINTS_BONUS_INSTRUCTOR?>" />
+                           value="<?php echo $conf->global->BBC_POINTS_BONUS_INSTRUCTOR ?>" />
                 </td>
             </tr>
         </table>
@@ -203,8 +142,8 @@ print load_fiche_titre($langs->trans("FLightLogSetup"), $linkback, 'title_setup'
                     <br/><span class="text-muted">Separer par des ; </span>
                 </td>
             </tr>
-
         </table>
+
         <input type="submit" />
     </form>
 <?php

--- a/class/bbctypes.class.php
+++ b/class/bbctypes.class.php
@@ -64,6 +64,36 @@ class Bbctypes extends CommonObject
     public $service;
 
     /**
+     * @var float
+     */
+    public $remboursement_km = 0;
+
+    /**
+     * @var int
+     */
+    public $points_pilote = 0;
+
+    /**
+     * @var float
+     */
+    public $cout_pilote = 0;
+
+    /**
+     * @var int
+     */
+    public $visible_graphique = 1;
+
+    /**
+     * @var int
+     */
+    public $visible_tableau = 1;
+
+    /**
+     * @var float
+     */
+    public $defraiement = 0;
+
+    /**
      * Constructor
      *
      * @param DoliDb $db Database handler
@@ -110,16 +140,26 @@ class Bbctypes extends CommonObject
         $sql .= 'numero,';
         $sql .= 'nom,';
         $sql .= 'fkService,';
-        $sql .= 'active';
-
+        $sql .= 'active,';
+        $sql .= 'remboursement_km,';
+        $sql .= 'points_pilote,';
+        $sql .= 'cout_pilote,';
+        $sql .= 'visible_graphique,';
+        $sql .= 'visible_tableau,';
+        $sql .= 'defraiement';
 
         $sql .= ') VALUES (';
 
         $sql .= ' ' . (!isset($this->numero) ? 'NULL' : $this->numero) . ',';
         $sql .= ' ' . (!isset($this->nom) ? 'NULL' : "'" . $this->db->escape($this->nom) . "'") . ',';
         $sql .= ' ' . (!isset($this->fkService) ? 'NULL' : "'" . $this->db->escape($this->fkService) . "'") . ',';
-        $sql .= ' ' . (!isset($this->active) ? 'NULL' : $this->active);
-
+        $sql .= ' ' . (!isset($this->active) ? 'NULL' : $this->active) . ',';
+        $sql .= ' ' . (float)$this->remboursement_km . ',';
+        $sql .= ' ' . (int)$this->points_pilote . ',';
+        $sql .= ' ' . (float)$this->cout_pilote . ',';
+        $sql .= ' ' . (int)$this->visible_graphique . ',';
+        $sql .= ' ' . (int)$this->visible_tableau . ',';
+        $sql .= ' ' . (float)$this->defraiement;
 
         $sql .= ')';
 
@@ -170,8 +210,13 @@ class Bbctypes extends CommonObject
         $sql .= " t.numero,";
         $sql .= " t.nom,";
         $sql .= " t.fkService,";
-        $sql .= " t.active";
-
+        $sql .= " t.active,";
+        $sql .= " t.remboursement_km,";
+        $sql .= " t.points_pilote,";
+        $sql .= " t.cout_pilote,";
+        $sql .= " t.visible_graphique,";
+        $sql .= " t.visible_tableau,";
+        $sql .= " t.defraiement";
 
         $sql .= ' FROM ' . MAIN_DB_PREFIX . $this->table_element . ' as t';
         if (null !== $ref) {
@@ -193,6 +238,12 @@ class Bbctypes extends CommonObject
                 $this->nom = $obj->nom;
                 $this->fkService = $obj->fkService;
                 $this->active = $obj->active;
+                $this->remboursement_km = (float)$obj->remboursement_km;
+                $this->points_pilote = (int)$obj->points_pilote;
+                $this->cout_pilote = (float)$obj->cout_pilote;
+                $this->visible_graphique = (int)$obj->visible_graphique;
+                $this->visible_tableau = (int)$obj->visible_tableau;
+                $this->defraiement = (float)$obj->defraiement;
 
                 if ($this->fkService) {
                     $this->service = new Product($this->db);
@@ -241,8 +292,13 @@ class Bbctypes extends CommonObject
         $sql .= " t.numero,";
         $sql .= " t.nom,";
         $sql .= " t.fkService,";
-        $sql .= " t.active";
-
+        $sql .= " t.active,";
+        $sql .= " t.remboursement_km,";
+        $sql .= " t.points_pilote,";
+        $sql .= " t.cout_pilote,";
+        $sql .= " t.visible_graphique,";
+        $sql .= " t.visible_tableau,";
+        $sql .= " t.defraiement";
 
         $sql .= ' FROM ' . MAIN_DB_PREFIX . $this->table_element . ' as t';
 
@@ -286,6 +342,12 @@ class Bbctypes extends CommonObject
                 $line->nom = $obj->nom;
                 $line->fkService = $obj->fkService;
                 $line->active = $obj->active;
+                $line->remboursement_km = (float)$obj->remboursement_km;
+                $line->points_pilote = (int)$obj->points_pilote;
+                $line->cout_pilote = (float)$obj->cout_pilote;
+                $line->visible_graphique = (int)$obj->visible_graphique;
+                $line->visible_tableau = (int)$obj->visible_tableau;
+                $line->defraiement = (float)$obj->defraiement;
 
                 $this->lines[$line->id] = $line;
             }
@@ -342,8 +404,13 @@ class Bbctypes extends CommonObject
         $sql .= ' numero = ' . (isset($this->numero) ? $this->numero : "null") . ',';
         $sql .= ' nom = ' . (isset($this->nom) ? "'" . $this->db->escape($this->nom) . "'" : "null") . ',';
         $sql .= ' fkService = ' . (isset($this->fkService) ? "'" . $this->db->escape($this->fkService) . "'" : "null") . ',';
-        $sql .= ' active = ' . (isset($this->active) ? $this->active : "null");
-
+        $sql .= ' active = ' . (isset($this->active) ? $this->active : "null") . ',';
+        $sql .= ' remboursement_km = ' . (float)$this->remboursement_km . ',';
+        $sql .= ' points_pilote = ' . (int)$this->points_pilote . ',';
+        $sql .= ' cout_pilote = ' . (float)$this->cout_pilote . ',';
+        $sql .= ' visible_graphique = ' . (int)$this->visible_graphique . ',';
+        $sql .= ' visible_tableau = ' . (int)$this->visible_tableau . ',';
+        $sql .= ' defraiement = ' . (float)$this->defraiement;
 
         $sql .= ' WHERE idType=' . $this->id;
 
@@ -592,6 +659,12 @@ class Bbctypes extends CommonObject
         $this->nom = '';
         $this->fkService = null;
         $this->active = '';
+        $this->remboursement_km = 0;
+        $this->points_pilote = 0;
+        $this->cout_pilote = 0;
+        $this->visible_graphique = 1;
+        $this->visible_tableau = 1;
+        $this->defraiement = 0;
     }
 
     /**
@@ -689,6 +762,36 @@ class BbctypesLine
     public $active;
 
     /**
+     * @var float
+     */
+    public $remboursement_km = 0;
+
+    /**
+     * @var int
+     */
+    public $points_pilote = 0;
+
+    /**
+     * @var float
+     */
+    public $cout_pilote = 0;
+
+    /**
+     * @var int
+     */
+    public $visible_graphique = 1;
+
+    /**
+     * @var int
+     */
+    public $visible_tableau = 1;
+
+    /**
+     * @var float
+     */
+    public $defraiement = 0;
+
+    /**
      * @return int
      */
     public function getId()
@@ -742,6 +845,54 @@ class BbctypesLine
     public function getLabel()
     {
         return "T" . $this->numero . '-' . $this->nom;
+    }
+
+    /**
+     * @return float
+     */
+    public function getRemboursementKm()
+    {
+        return $this->remboursement_km;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPointsPilote()
+    {
+        return $this->points_pilote;
+    }
+
+    /**
+     * @return float
+     */
+    public function getCoutPilote()
+    {
+        return $this->cout_pilote;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isVisibleGraphique()
+    {
+        return (bool)$this->visible_graphique;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isVisibleTableau()
+    {
+        return (bool)$this->visible_tableau;
+    }
+
+    /**
+     * @return float
+     */
+    public function getDefraiement()
+    {
+        return $this->defraiement;
     }
 
 }

--- a/class/missions/FlightMission.php
+++ b/class/missions/FlightMission.php
@@ -46,6 +46,11 @@ class FlightMission
     private $date;
 
     /**
+     * @var int
+     */
+    private $fkType;
+
+    /**
      * FlightMission constructor.
      *
      * @param int      $id
@@ -54,8 +59,9 @@ class FlightMission
      * @param string   $kilometersComment
      * @param int      $numberOfKilometers
      * @param DateTime $date
+     * @param int      $fkType
      */
-    public function __construct($id, $startPoint, $endPoint, $kilometersComment, $numberOfKilometers, DateTime $date)
+    public function __construct($id, $startPoint, $endPoint, $kilometersComment, $numberOfKilometers, DateTime $date, $fkType = 0)
     {
         $this->id = (int)$id;
         $this->startPoint = $startPoint;
@@ -63,6 +69,7 @@ class FlightMission
         $this->kilometersComment = $kilometersComment;
         $this->numberOfKilometers = $numberOfKilometers;
         $this->date = $date;
+        $this->fkType = (int)$fkType;
     }
 
     /**
@@ -111,5 +118,13 @@ class FlightMission
     public function getDate()
     {
         return $this->date;
+    }
+
+    /**
+     * @return int
+     */
+    public function getFkType()
+    {
+        return $this->fkType;
     }
 }

--- a/command/CreateExpenseNoteCommandHandler.php
+++ b/command/CreateExpenseNoteCommandHandler.php
@@ -146,12 +146,17 @@ class CreateExpenseNoteCommandHandler
      */
     private function addKilometersLine(FlightMission $currentFlightForQuarter, $expenseNote)
     {
+        $rateKm = $this->getRemboursementKmForFlight($currentFlightForQuarter);
+        if ($rateKm <= 0 || $currentFlightForQuarter->getNumberOfKilometers() <= 0) {
+            return $expenseNote;
+        }
+
         $object_ligne = new ExpenseReportLine($this->db);
         $object_ligne->comments = $this->langs->trans(sprintf("Vol (id: %d) %s à %s  détail: %s",
             $currentFlightForQuarter->getId(), $currentFlightForQuarter->getStartPoint(),
             $currentFlightForQuarter->getEndPoint(), $currentFlightForQuarter->getKilometersComment()));
         $object_ligne->qty = $currentFlightForQuarter->getNumberOfKilometers();
-        $object_ligne->value_unit = $this->getAmountByKilometer();
+        $object_ligne->value_unit = $rateKm;
 
         $object_ligne->date = $currentFlightForQuarter->getDate()->format('Y-m-d');
 
@@ -180,11 +185,16 @@ class CreateExpenseNoteCommandHandler
      */
     private function addMissionLine(FlightMission $currentFlightForQuarter, ExpenseReport $expenseReport)
     {
+        $defraiement = $this->getDefraiementForFlight($currentFlightForQuarter);
+        if ($defraiement <= 0) {
+            return $expenseReport;
+        }
+
         $object_ligne = new ExpenseReportLine($this->db);
         $object_ligne->comments = sprintf("Vol (id: %d) %s à %s", $currentFlightForQuarter->getId(),
             $currentFlightForQuarter->getStartPoint(), $currentFlightForQuarter->getEndPoint());
         $object_ligne->qty = 1;
-        $object_ligne->value_unit = $this->getAmountByMission();
+        $object_ligne->value_unit = $defraiement;
 
         $object_ligne->date = $currentFlightForQuarter->getDate()->format('Y-m-d');
 
@@ -206,26 +216,43 @@ class CreateExpenseNoteCommandHandler
     }
 
     /**
-     * Get the unit price pe KM.
+     * Returns the km reimbursement rate for a given flight, falling back to global config.
      *
-     * @return int
+     * @param FlightMission $flight
+     *
+     * @return float
      */
-    private function getAmountByKilometer()
+    private function getRemboursementKmForFlight(FlightMission $flight)
     {
-        return isset($this->conf->global->BBC_FLIGHT_LOG_TAUX_REMB_KM) ? $this->conf->global->BBC_FLIGHT_LOG_TAUX_REMB_KM : 0;
+        if ($flight->getFkType() > 0) {
+            $type = new \Bbctypes($this->db);
+            if ($type->fetch($flight->getFkType()) > 0 && $type->remboursement_km > 0) {
+                return (float)$type->remboursement_km;
+            }
+        }
+
+        return isset($this->conf->global->BBC_FLIGHT_LOG_TAUX_REMB_KM) ? (float)$this->conf->global->BBC_FLIGHT_LOG_TAUX_REMB_KM : 0;
     }
 
     /**
-     * @return mixed
+     * Returns the expense allowance amount for a given flight, falling back to global config.
+     *
+     * @param FlightMission $flight
+     *
+     * @return float
      */
-    private function getAmountByMission()
+    private function getDefraiementForFlight(FlightMission $flight)
     {
-        return $this->conf->global->BBC_FLIGHT_LOG_UNIT_PRICE_MISSION;
+        if ($flight->getFkType() > 0) {
+            $type = new \Bbctypes($this->db);
+            if ($type->fetch($flight->getFkType()) > 0 && $type->defraiement > 0) {
+                return (float)$type->defraiement;
+            }
+        }
+
+        return isset($this->conf->global->BBC_FLIGHT_LOG_UNIT_PRICE_MISSION) ? (float)$this->conf->global->BBC_FLIGHT_LOG_UNIT_PRICE_MISSION : 0;
     }
 
-    /**
-     * @return string
-     */
     private function getVatRate()
     {
         return '0.000';

--- a/core/modules/modFlightLog.class.php
+++ b/core/modules/modFlightLog.class.php
@@ -523,17 +523,21 @@ class modFlightLog extends DolibarrModules
 
     private function initFlightTypeDictionnary()
     {
+        $selectFields = 'f.idType, f.numero, f.nom, f.fkService,'
+            . ' f.remboursement_km, f.points_pilote, f.cout_pilote, f.defraiement,'
+            . ' f.visible_graphique, f.visible_tableau, f.active';
+
         $this->dictionaries = array(
-            'langs' => 'mylangfile@mymodule',
-            'tabname' => array(MAIN_DB_PREFIX . "bbc_types"),
-            'tablib' => array("Types de vols"),
-            'tabsql' => array('SELECT f.idType, f.numero, f.nom, f.active FROM ' . MAIN_DB_PREFIX . 'bbc_types as f',),
-            'tabsqlsort' => array("numero ASC"),
-            'tabfield' => array("idType,numero,nom"),
-            'tabfieldvalue' => array("numero,nom"),
-            'tabfieldinsert' => array("numero,nom"),
-            'tabrowid' => array("idType"),
-            'tabcond' => array('$conf->flightlog->enabled'),
+            'langs'          => 'mylangfile@mymodule',
+            'tabname'        => array(MAIN_DB_PREFIX . 'bbc_types'),
+            'tablib'         => array('Types de vols'),
+            'tabsql'         => array('SELECT ' . $selectFields . ' FROM ' . MAIN_DB_PREFIX . 'bbc_types as f'),
+            'tabsqlsort'     => array('numero ASC'),
+            'tabfield'       => array('idType,numero,nom,fkService,remboursement_km,points_pilote,cout_pilote,defraiement,visible_graphique,visible_tableau'),
+            'tabfieldvalue'  => array('numero,nom,fkService,remboursement_km,points_pilote,cout_pilote,defraiement,visible_graphique,visible_tableau'),
+            'tabfieldinsert' => array('numero,nom,fkService,remboursement_km,points_pilote,cout_pilote,defraiement,visible_graphique,visible_tableau'),
+            'tabrowid'       => array('idType'),
+            'tabcond'        => array('$conf->flightlog->enabled'),
         );
     }
 

--- a/query/BillableFlightQueryHandler.php
+++ b/query/BillableFlightQueryHandler.php
@@ -172,45 +172,57 @@ class BillableFlightQueryHandler
     }
 
     /**
-     * Returns the number of points if set in the config, if not return the price of the service.
+     * Returns the financial factor (points or cost) for a flight type.
+     * For bonus types (T1, T2): returns points_pilote, falling back to BBC_POINTS_BONUS_X.
+     * For cost types (T3, T4, T6, T7): returns cout_pilote, falling back to service price_ttc.
+     * For role types (orga, orga_T6): returns global constants.
      *
      * @param string $type
      *
-     * @return int
+     * @return float
      */
     private function getFactorByType($type)
     {
         switch ($type) {
             case 'orga':
-                return $this->conf->BBC_POINTS_BONUS_ORGANISATOR;
+                return (float)$this->conf->BBC_POINTS_BONUS_ORGANISATOR;
             case 'orga_T6':
-                return $this->conf->BBC_POINTS_BONUS_INSTRUCTOR;
+                return (float)$this->conf->BBC_POINTS_BONUS_INSTRUCTOR;
         }
 
-        $constVariableName = 'BBC_POINTS_BONUS_' . $type;
-        if (!isset($this->conf->$constVariableName) || empty($this->conf->$constVariableName) || $this->conf->$constVariableName < 0) {
-            return $this->getFactorForService($type);
-        }
-
-        return (int) $this->conf->$constVariableName;
-
-    }
-
-    /**
-     * @param string $type
-     *
-     * @return float
-     */
-    private function getFactorForService($type)
-    {
-        $service = new Bbctypes($this->db);
-        $fetchResult = $service->fetch($type);
+        $bbcType = new Bbctypes($this->db);
+        $fetchResult = $bbcType->fetch((int)$type);
 
         if ($fetchResult <= 0) {
-            throw new \InvalidArgumentException('Service not found');
+            return 0;
         }
 
-        return $service->getService()->price_ttc;
+        // Bonus types: T1, T2 → use points_pilote
+        if (in_array((int)$type, [1, 2])) {
+            if ($bbcType->points_pilote > 0) {
+                return (float)$bbcType->points_pilote;
+            }
+
+            // Backward-compatibility: fall back to global constant
+            $constVariableName = 'BBC_POINTS_BONUS_' . $type;
+            if (!empty($this->conf->$constVariableName) && $this->conf->$constVariableName > 0) {
+                return (float)$this->conf->$constVariableName;
+            }
+
+            return 0;
+        }
+
+        // Cost types: T3, T4, T6, T7 → use cout_pilote
+        if ($bbcType->cout_pilote > 0) {
+            return (float)$bbcType->cout_pilote;
+        }
+
+        // Backward-compatibility: fall back to service price
+        if ($bbcType->fkService) {
+            return (float)$bbcType->getService()->price_ttc;
+        }
+
+        return 0;
     }
 
 

--- a/query/FlightForQuarterAndPilotQueryHandler.php
+++ b/query/FlightForQuarterAndPilotQueryHandler.php
@@ -47,7 +47,7 @@ class FlightForQuarterAndPilotQueryHandler
                     $flight = $this->db->fetch_object($resql);
                     if ($flight) {
                         $flights[] = new FlightMission($flight->rowid, $flight->lieuD, $flight->lieuA,
-                            $flight->justif_kilometers, $flight->kilometers, new \DateTime($flight->date));
+                            $flight->justif_kilometers, $flight->kilometers, new \DateTime($flight->date), $flight->fk_type);
                     }
                     $i++;
                 }

--- a/readFlights.php
+++ b/readFlights.php
@@ -88,22 +88,40 @@ if ($num) {
 }
 
 
+// Load flight types for visible_tableau. T1 and T2 stay in the hardcoded bonus section.
+$allFlightTypes = fetchBbcFlightTypes(1);
+$t1Type = null;
+$t2Type = null;
+$visibleCostTypes = [];
+foreach ($allFlightTypes as $ft) {
+    if ((int)$ft->numero === 1) { $t1Type = $ft; continue; }
+    if ((int)$ft->numero === 2) { $t2Type = $ft; continue; }
+    if ($ft->isVisibleTableau()) {
+        $visibleCostTypes[] = $ft;
+    }
+}
+$showT1 = $t1Type === null || $t1Type->isVisibleTableau();
+$showT2 = $t2Type === null || $t2Type->isVisibleTableau();
+
 print '<div class="tabBar">';
 print '<table class="" width="100%">';
 
 print '<tbody>';
 print '<tr class="liste_titre">';
 print '<td colspan="2">Nom</td>';
-print '<td class="liste_titre _alignCenter" colspan="2">' . $langs->trans("Type 1 : <br/>Sponsor") . '</td>';
-print '<td class="liste_titre _alignCenter" colspan="2">' . $langs->trans("Type 2 : <br/>Baptême") . '</td>';
+if ($showT1) {
+    print '<td class="liste_titre _alignCenter" colspan="2">' . $langs->trans("Type 1 : <br/>Sponsor") . '</td>';
+}
+if ($showT2) {
+    print '<td class="liste_titre _alignCenter" colspan="2">' . $langs->trans("Type 2 : <br/>Baptême") . '</td>';
+}
 print '<td class="liste_titre _alignCenter" colspan="2">' . $langs->trans("Orga. <br/>(T1/T2)") . '</td>';
 print '<td class="liste_titre _alignCenter" colspan="2">' . $langs->trans("Instructeur <br/>(orga T6)") . '</td>';
 print '<td class="liste_titre _alignCenter" >' . $langs->trans("Total bonus") . '</td>';
-print '<td class="liste_titre _alignCenter" colspan="2">' . $langs->trans("Type 3 : <br/>Privé") . '</td>';
-print '<td class="liste_titre _alignCenter" colspan="2">' . $langs->trans("Type 4: <br/>Meeting") . '</td>';
-print '<td class="liste_titre _alignCenter" colspan="1">' . $langs->trans("Type 5: <br/>Chambley") . '</td>';
-print '<td class="liste_titre _alignCenter" colspan="2">' . $langs->trans("Type 6: <br/>instruction") . '</td>';
-print '<td class="liste_titre _alignCenter" colspan="2">' . $langs->trans("Type 7: <br/>vols < 50 ") . '</td>';
+foreach ($visibleCostTypes as $ft) {
+    $colspan = $ft->cout_pilote > 0 ? 2 : 1;
+    print '<td class="liste_titre _alignCenter" colspan="' . $colspan . '">(T' . $ft->numero . ') ' . $ft->nom . '</td>';
+}
 print '<td class="liste_titre _alignCenter" colspan="2">' . $langs->trans("Réparations") . '</td>';
 print '<td class="liste_titre _alignCenter" colspan="1">' . $langs->trans("Facture") . '</td>';
 print '<td class="liste_titre _alignCenter" colspan="1">' . $langs->trans("A payer") . '</td>';
@@ -112,11 +130,14 @@ print '<tr>';
 print '<tr class="liste_titre">';
 print '<td colspan="2" class="liste_titre"></td>';
 
-print '<td class="liste_titre"> # </td>';
-print '<td class="liste_titre"> Pts </td>';
-
-print '<td class="liste_titre"> # </td>';
-print '<td class="liste_titre"> Pts </td>';
+if ($showT1) {
+    print '<td class="liste_titre"> # </td>';
+    print '<td class="liste_titre"> Pts </td>';
+}
+if ($showT2) {
+    print '<td class="liste_titre"> # </td>';
+    print '<td class="liste_titre"> Pts </td>';
+}
 
 print '<td class="liste_titre"> # </td>';
 print '<td class="liste_titre"> Pts </td>';
@@ -126,22 +147,13 @@ print '<td class="liste_titre"> Pts </td>';
 
 print '<td class="liste_titre"> Pts</td>';
 
-print '<td class="liste_titre"> # </td>';
-print '<td class="liste_titre"> € </td>';
+foreach ($visibleCostTypes as $ft) {
+    print '<td class="liste_titre"> # </td>';
+    if ($ft->cout_pilote > 0) {
+        print '<td class="liste_titre"> € </td>';
+    }
+}
 
-print '<td class="liste_titre"> # </td>';
-print '<td class="liste_titre"> € </td>';
-
-print '<td class="liste_titre"> # </td>';
-
-print '<td class="liste_titre"> # </td>';
-print '<td class="liste_titre"> € </td>';
-
-// T7
-print '<td class="liste_titre"> #</td>';
-print '<td class="liste_titre"> €</td>';
-
-// Damage
 print '<td class="liste_titre"> €</td>';
 print '<td class="liste_titre"> fact. €</td>';
 
@@ -164,22 +176,18 @@ function pilotStatus($id){
 }
 
 $total = 0;
-
+$totalWithoutPts = 0;
 $totalT1 = 0;
 $totalT2 = 0;
-$totalT3 = 0;
-$totalT4 = 0;
-$totalT5 = 0;
-$totalT6 = 0;
-$totalT7 = 0;
-
-$totalWithoutPts = 0;
-
 $totalPtsMission1 = 0;
 $totalPtsMission2 = 0;
 $totalPtsOrga = 0;
 $totalPtsInstructor = 0;
 $totalPts = 0;
+$totalByType = [];
+foreach ($visibleCostTypes as $ft) {
+    $totalByType[$ft->numero] = 0;
+}
 
 /**
  * @var int   $key
@@ -187,31 +195,32 @@ $totalPts = 0;
  */
 foreach ($tableQueryHandler->__invoke($tableQuery) as $key => $pilot) {
     $total += $pilot->getTotalBill()->getValue();
+
     $totalT1 += $pilot->getCountForType('1')->getCount();
     $totalT2 += $pilot->getCountForType('2')->getCount();
-    $totalT3 += $pilot->getCountForType('3')->getCount();
-    $totalT4 += $pilot->getCountForType('4')->getCount();
-    $totalT5 += $pilot->getCountForType('5')->getCount();
-    $totalT6 += $pilot->getCountForType('6')->getCount();
-    $totalT7 += $pilot->getCountForType('7')->getCount();
-
     $totalPtsMission1 += $pilot->getCountForType('1')->getCost()->getValue();
     $totalPtsMission2 += $pilot->getCountForType('2')->getCost()->getValue();
     $totalPtsOrga += $pilot->getCountForType('orga')->getCost()->getValue();
     $totalPtsInstructor += $pilot->getCountForType('orga_T6')->getCost()->getValue();
     $totalPts += $pilot->getFlightBonus()->getValue();
-
     $totalWithoutPts += $pilot->getFlightsCost()->getValue();
+
+    foreach ($visibleCostTypes as $ft) {
+        $totalByType[$ft->numero] += $pilot->getCountForType((string)$ft->numero)->getCount();
+    }
 
     print '<tr class="oddeven">';
     print '<td>' . $pilot->getId() . '</td>';
     print '<td>' . pilotStatus($pilot->getId()) . $pilot->getName() . '</td>';
 
-    print '<td>' . $pilot->getCountForType('1')->getCount() . '</td>';
-    print '<td>' . $pilot->getCountForType('1')->getCost()->getValue() . '</td>';
-
-    print '<td>' . $pilot->getCountForType('2')->getCount() . '</td>';
-    print '<td>' . $pilot->getCountForType('2')->getCost()->getValue() . '</td>';
+    if ($showT1) {
+        print '<td>' . $pilot->getCountForType('1')->getCount() . '</td>';
+        print '<td>' . $pilot->getCountForType('1')->getCost()->getValue() . '</td>';
+    }
+    if ($showT2) {
+        print '<td>' . $pilot->getCountForType('2')->getCount() . '</td>';
+        print '<td>' . $pilot->getCountForType('2')->getCost()->getValue() . '</td>';
+    }
 
     print '<td>' . $pilot->getCountForType('orga')->getCount() . '</td>';
     print '<td>' . $pilot->getCountForType('orga')->getCost()->getValue() . '</td>';
@@ -221,19 +230,13 @@ foreach ($tableQueryHandler->__invoke($tableQuery) as $key => $pilot) {
 
     print sprintf('<td class="%s">', $pilot->getFlightBonus()->getValue() === 0?'text-muted':'text-bold'). $pilot->getFlightBonus()->getValue() . ' pts</td>';
 
-    print '<td>' . $pilot->getCountForType('3')->getCount() . '</td>';
-    print '<td>' . price($pilot->getCountForType('3')->getCost()->getValue()) . '€</td>';
-
-    print '<td>' . $pilot->getCountForType('4')->getCount() . '</td>';
-    print '<td>' . price($pilot->getCountForType('4')->getCost()->getValue()) . '€</td>';
-
-    print '<td>' . $pilot->getCountForType('5')->getCount() . '</td>';
-
-    print '<td>' . $pilot->getCountForType('6')->getCount() . '</td>';
-    print '<td>' . price($pilot->getCountForType('6')->getCost()->getValue()) . '€</td>';
-
-    print '<td>' . $pilot->getCountForType('7')->getCount() . '</td>';
-    print '<td>' . price($pilot->getCountForType('7')->getCost()->getValue()) . '€</td>';
+    foreach ($visibleCostTypes as $ft) {
+        $typeNum = (string)$ft->numero;
+        print '<td>' . $pilot->getCountForType($typeNum)->getCount() . '</td>';
+        if ($ft->cout_pilote > 0) {
+            print '<td>' . price($pilot->getCountForType($typeNum)->getCost()->getValue()) . '€</td>';
+        }
+    }
 
     print '<td>' . price($pilot->damageCost()->getValue()) . '€</td>';
     print '<td>' . price($pilot->invoicedDamageCost()->getValue()) . '€</td>';
@@ -243,37 +246,34 @@ foreach ($tableQueryHandler->__invoke($tableQuery) as $key => $pilot) {
     print '</tr>';
 }
 
+// Totals row
 print '<tr class="oddeven">';
 print '<td></td>';
 print '<td></td>';
 
-print '<td>' . $totalT1 . '</td>';
-print '<td>' . $totalPtsMission1 . '</td>';
+if ($showT1) {
+    print '<td>' . $totalT1 . '</td>';
+    print '<td>' . $totalPtsMission1 . '</td>';
+}
+if ($showT2) {
+    print '<td>' . $totalT2 . '</td>';
+    print '<td>' . $totalPtsMission2 . '</td>';
+}
 
-print '<td>' . $totalT2 . '</td>';
-print '<td>' . $totalPtsMission2 . '</td>';
-
-print '<td>' . '</td>';
+print '<td></td>';
 print '<td>' . $totalPtsOrga . '</td>';
 
-print '<td>' . '</td>';
+print '<td></td>';
 print '<td>' . $totalPtsInstructor . '</td>';
 
 print '<td><b>' . $totalPts . '</b></td>';
 
-print '<td>' . $totalT3 . '</td>';
-print '<td></td>';
-
-print '<td>' . $totalT4. '</td>';
-print '<td></td>';
-
-print '<td>' . $totalT5 . '</td>';
-
-print '<td>' . $totalT6 . '</td>';
-print '<td></td>';
-
-print '<td>' . $totalT7 . '</td>';
-print '<td></td>';
+foreach ($visibleCostTypes as $ft) {
+    print '<td>' . ($totalByType[$ft->numero] ?? 0) . '</td>';
+    if ($ft->cout_pilote > 0) {
+        print '<td></td>';
+    }
+}
 
 print '<td></td>';
 print '<td></td>';

--- a/sql/update_1.13-1.14.sql
+++ b/sql/update_1.13-1.14.sql
@@ -1,0 +1,7 @@
+ALTER TABLE llx_bbc_types
+    ADD COLUMN remboursement_km    DECIMAL(10, 2) NOT NULL DEFAULT 0 COMMENT 'Taux de remboursement kilométrique (€/km)',
+    ADD COLUMN points_pilote       INT            NOT NULL DEFAULT 0 COMMENT 'Points attribués au pilote par vol',
+    ADD COLUMN cout_pilote         DECIMAL(10, 2) NOT NULL DEFAULT 0 COMMENT 'Coût facturé au pilote par vol (€)',
+    ADD COLUMN visible_graphique   TINYINT        NOT NULL DEFAULT 1 COMMENT 'Visible dans les graphiques',
+    ADD COLUMN visible_tableau     TINYINT        NOT NULL DEFAULT 1 COMMENT 'Visible dans le tableau récapitulatif',
+    ADD COLUMN defraiement         DECIMAL(10, 2) NOT NULL DEFAULT 0 COMMENT 'Montant du défraiement par vol (€)';


### PR DESCRIPTION
## Résumé

Chaque type de vol (`llx_bbc_types`) dispose désormais de six champs de configuration administrables, en remplacement des constantes globales qui ne permettaient pas de différencier les types :

| Champ | Description |
|---|---|
| `remboursement_km` | Taux de remboursement kilométrique (€/km) utilisé dans les notes de frais |
| `points_pilote` | Points bonus attribués au pilote par vol (types T1/T2) |
| `cout_pilote` | Coût facturé au pilote par vol en € (types T3–T7) |
| `defraiement` | Forfait de défraiement par vol utilisé dans les notes de frais |
| `visible_graphique` | Afficher/masquer le type dans les graphiques statistiques |
| `visible_tableau` | Afficher/masquer la colonne du type dans le tableau récapitulatif |

## Fichiers modifiés

### Base de données
- **`sql/update_1.13-1.14.sql`** — migration `ALTER TABLE` ajoutant les 6 colonnes à `llx_bbc_types`

### Modèle
- **`class/bbctypes.class.php`** — nouvelles propriétés dans `Bbctypes` et `BbctypesLine` ; méthodes CRUD (`create`, `fetch`, `fetchAll`, `update`) mises à jour ; getters ajoutés à `BbctypesLine`
- **`class/missions/FlightMission.php`** — transporte désormais `fk_type` pour permettre la résolution des taux par type

### Administration
- **`admin/vol.php`** — formulaire de dictionnaire refondu : toute la configuration par type est dans un seul tableau (service, remb. km, points, coût, défraiement, cases à cocher visibilité)

### Calcul des notes de frais
- **`query/FlightForQuarterAndPilotQueryHandler.php`** — passe `fk_type` à `FlightMission`
- **`command/CreateExpenseNoteCommandHandler.php`** — utilise `remboursement_km` et `defraiement` du type de vol ; rétrocompatible (repli sur `BBC_FLIGHT_LOG_TAUX_REMB_KM` / `BBC_FLIGHT_LOG_UNIT_PRICE_MISSION` si les champs sont à 0)

### Calcul des factures
- **`query/BillableFlightQueryHandler.php`** — utilise `points_pilote` pour T1/T2 et `cout_pilote` pour T3–T7 ; rétrocompatible (repli sur `BBC_POINTS_BONUS_X` / `price_ttc` du service)

### Page de résumé
- **`Http/Web/Controller/StatisticalGraphController.php`** — filtre les types via `visible_graphique` au lieu de la liste en dur `[1, 2, 3, 4, 6]`
- **`readFlights.php`** — colonnes du tableau pilotées par `visible_tableau` ; T1/T2 restent dans la section bonus, les autres types dans la section coût

## Plan de test

- [ ] Exécuter la migration `update_1.13-1.14.sql` sur l'instance de développement
- [ ] Vérifier que le formulaire `admin/vol.php` affiche et sauvegarde correctement les 6 champs pour chaque type
- [ ] Configurer des valeurs non nulles pour `remboursement_km` et `defraiement` sur T1/T2, puis générer une note de frais et vérifier les montants
- [ ] Configurer `points_pilote` sur T1/T2 et `cout_pilote` sur T3–T7, puis générer une facture et vérifier les montants
- [ ] Désactiver `visible_tableau` sur un type (ex. T5) et vérifier que sa colonne disparaît du tableau récapitulatif
- [ ] Désactiver `visible_graphique` sur un type et vérifier qu'il n'apparaît plus dans le graphique par type
- [ ] Vérifier la rétrocompatibilité : avec tous les nouveaux champs à 0, le comportement doit être identique à l'ancien (repli sur les constantes globales / `price_ttc`)

https://claude.ai/code/session_01QDCYEKRNnVyGXc42ySPGic

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDCYEKRNnVyGXc42ySPGic)_